### PR TITLE
Fix padding logic in writeRandomPadMax16 function

### DIFF
--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -65,12 +65,9 @@ export const getKeyAuthor = (key: proto.IMessageKey | undefined | null, meId = '
 
 export const writeRandomPadMax16 = (msg: Uint8Array) => {
 	const pad = randomBytes(1)
-	pad[0] &= 0xf
-	if (!pad[0]) {
-		pad[0] = 0xf
-	}
+	const padLength = (pad[0]! & 0x0f) + 1
 
-	return Buffer.concat([msg, Buffer.alloc(pad[0], pad[0])])
+	return Buffer.concat([msg, Buffer.alloc(padLength, padLength)])
 }
 
 export const unpadRandomMax16 = (e: Uint8Array | Buffer) => {


### PR DESCRIPTION
Simplifies and corrects the calculation of the padding length to always be between 1 and 16 bytes. The new logic ensures the padding is never zero and is more concise.