### PR TITLE
fix: add audio-decode dependency for waveform functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@cacheable/node-cache": "^1.4.0",
     "@hapi/boom": "^9.1.3",
     "async-mutex": "^0.5.0",
+    "audio-decode": "^2.1.3",
     "axios": "^1.6.0",
     "libsignal": "github:WhiskeySockets/libsignal-node",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Este PR adiciona a dependência audio-decode que estava faltando no projeto, corrigindo a funcionalidade de geração de waveform para áudios.

Problema
A funcionalidade de waveform não estava funcionando devido à ausência da dependência audio-decode no package.json

Solução
Adicionada a dependência audio-decode nas dependências do projeto
Isso permite que a biblioteca processe corretamente os arquivos de áudio para gerar waveforms
Requisitos de uso
Para utilizar a funcionalidade de waveform corretamente, é necessário que os arquivos de áudio sejam enviados no formato OGG Opus.

Alterações
package.json : Adicionada dependência audio-decode
Testes
✅ Funcionalidade de waveform agora funciona corretamente com arquivos OGG Opus
✅ Build do projeto executa sem erros